### PR TITLE
disabling SSR for now

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,12 +65,16 @@
                   "maximumError": "100kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "ssr": false,
+              "prerender": false
             },
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "ssr": false,
+              "prerender": false
             }
           },
           "defaultConfiguration": "production"


### PR DESCRIPTION
If you look right now (before merging) you will see the [API currently shows 287 left](https://datieskca7hlzshr3hgso4vacu0yfscv.lambda-url.us-east-1.on.aws/) but the [live site shows 289 left](https://www.debookmagickey.com/). So SSR is not working correctly and we are not fetching. 

Until we figure this out we should turn off SSR everywhere so that the progress bars show live data